### PR TITLE
Fix data structure in "Joins in EQL"

### DIFF
--- a/modules/tutorial-eql-pathom-overview/pages/index.adoc
+++ b/modules/tutorial-eql-pathom-overview/pages/index.adoc
@@ -202,14 +202,14 @@ on `:list/items` like so:
 {:all-lists
  [{:list/id 1
    :list/name "Personal"
-   :list/items [{:todo/label "Buy Milk"
-                 :todo/label "Cook Dinner"
-                 :todo/label "Mail Letter"}]}
+   :list/items [{:todo/label "Buy Milk"}
+                {:todo/label "Cook Dinner"}
+                {:todo/label "Mail Letter"}]}
   {:list/id 2
    :list/name "Work"
-   :list/items [{:todo/label "Write TPS Report"
-                 :todo/label "Send Emails"
-                 :todo/label "Have Meeting"}]}]}
+   :list/items [{:todo/label "Write TPS Report"}
+                {:todo/label "Send Emails"}
+                {:todo/label "Have Meeting"}]}]}
 ----
 
 Notice a couple of things about the example above:


### PR DESCRIPTION
In the last example of "Joins in EQL" subsection, :list/items field in returned data structure should be [{:todo/label ...} {:todo/label ...} {:todo/label...}] instead of [{:todo/label ... :todo/label ... :todo/label ...}]